### PR TITLE
Fix iframe in Grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - 80:3000
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=secret
+      - GF_PANELS_DISABLE_SANITIZE_HTML=true
     volumes:
       - "./packages/grafana/volume:/var/lib/grafana"
       - "./packages/grafana/provisioning:/etc/grafana/provisioning"


### PR DESCRIPTION
# The problem

The Grafana dashboard shows the html/script instead of the lighthouse report website.

<img width="1169" alt="Single_Web_Page_Audit_-_Grafana" src="https://user-images.githubusercontent.com/7198934/58426088-dac2da80-809b-11e9-90ae-6422a1438e39.png">

## The solution

<img width="1098" alt="Single_Web_Page_Audit_-_Grafana" src="https://user-images.githubusercontent.com/7198934/58426028-b5ce6780-809b-11e9-8faf-582b87b306dc.png">

Grafana version 6 introduced a breaking change for the *Text Panels* which blocks the custom scripts/html.

> Text Panel: The text panel does no longer by default allow unsantizied HTML. #4117. This means that if you have text panels with scripts tags they will no longer work as before. To enable unsafe javascript execution in text panels enable the settings disable_sanitize_html under the section [panels] in your Grafana ini file, or set env variable GF_PANELS_DISABLE_SANITIZE_HTML=true.